### PR TITLE
Update to 2020.02.004-0.29.006

### DIFF
--- a/board/shredos/fsoverlay/usr/bin/nwipe_launcher
+++ b/board/shredos/fsoverlay/usr/bin/nwipe_launcher
@@ -3,7 +3,9 @@
 # trap the ctrl+c signal
 trap "echo" INT
 
+# run nwipe with a time stamped log file
 while true
 do
-    /usr/bin/nwipe
+    /usr/bin/nwipe --logfile=nwipe_log_$(date +%Y%m%d-%H%M%S).txt
 done
+

--- a/package/nwipe/nwipe.hash
+++ b/package/nwipe/nwipe.hash
@@ -1,2 +1,2 @@
-sha1   2b8060aa08fc1350b42e7a5b8a4d8850571904c8  nwipe-v0.29.002.tar.gz
+sha1    8fcfc811b72fe60f432cb1030df2b44a93b1b7b2  nwipe-v0.29.006.tar.gz
  

--- a/package/nwipe/nwipe.mk
+++ b/package/nwipe/nwipe.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-NWIPE_VERSION = v0.29.002
+NWIPE_VERSION = v0.29.006
 NWIPE_SITE = $(call github,PartialVolume,nwipe,$(NWIPE_VERSION))
 NWIPE_DEPENDENCIES = ncurses parted dmidecode coreutils
 


### PR DESCRIPTION
Changes include:
- Nwipe logs to a timestamped file so the results can be reviewed.
- Fix error reporting on control -c prior to a wipe starting.
- Add control A to select/deselect a drive for wiping.
- Warn user about no drives having been selected if try try to start a wipe and have not actually selected one or more drives.