### PR TITLE
package/{nwipe,hexedit}: ensure use of correct autotools binaries (#26)

### DIFF
--- a/package/hexedit/hexedit.mk
+++ b/package/hexedit/hexedit.mk
@@ -9,7 +9,7 @@ HEXEDIT_SITE = $(call github,pixel,hexedit,$(HEXEDIT_VERSION))
 HEXEDIT_DEPENDENCIES = ncurses parted 
 
 define HEXEDIT_INITSH
-	(cd $(@D) && ./autogen.sh);
+	(cd $(@D) && PATH="../../host/bin:${PATH}" ./autogen.sh);
 endef
 
 HEXEDIT_POST_PATCH_HOOKS += HEXEDIT_INITSH

--- a/package/nwipe/nwipe.mk
+++ b/package/nwipe/nwipe.mk
@@ -9,7 +9,7 @@ NWIPE_SITE = $(call github,PartialVolume,nwipe,$(NWIPE_VERSION))
 NWIPE_DEPENDENCIES = ncurses parted dmidecode coreutils
 
 define NWIPE_INITSH
-	(cd $(@D) && cp ../../../package/nwipe/002-nwipe-banner-patch.sh $(@D) && ./002-nwipe-banner-patch.sh  && ./autogen.sh);
+	(cd $(@D) && cp ../../../package/nwipe/002-nwipe-banner-patch.sh $(@D) && ./002-nwipe-banner-patch.sh  && PATH="../../host/bin:${PATH}" ./autogen.sh);
 endef
 
 NWIPE_POST_PATCH_HOOKS += NWIPE_INITSH


### PR DESCRIPTION
Ensure that the post patch hooks call use the correct autotools binaries
when calling autogen.sh for ShredOS-specific packages. Failing to
explicitly prepend `output/host/bin` to the PATH when calling autogen.sh
can lead to the incorrect use of system packages and build failure.