### PR TITLE
Merge pull request #255 from PartialVolume/Ping_server_and_wait

### DIFF
--- a/board/shredos/fsoverlay/usr/bin/nwipe_launcher
+++ b/board/shredos/fsoverlay/usr/bin/nwipe_launcher
@@ -19,6 +19,12 @@ exclude_boot_disc=0
 # Flag indicates user specified drives to be excluded from list or autonuke
 exclude_drives=0
 
+# Flag indicates whether a transfer failure occurred when outputing pdfs & logs to server
+transfer_status="SUCCESS"
+
+# supplementary nwipe options are appended to this string by this launcher script
+launcher_options=""
+
 # countdown on screen from 30s with numeric digits, checking the sha1 of dmesg every 5 secs
 # will exit countdown before reaching zero if no USB activity for 5 seconds
 loop_count_total=30
@@ -119,6 +125,8 @@ else
 	fi
 fi
 
+
+
 # ----
 # Read the kernel command line for the option shredos_config
 # and if it exists and starts with tftp then try reading nwipe.conf and
@@ -175,25 +183,25 @@ then
 	# It is necessary for the server to be online BEFORE nwipe starts, on some systems
 	# the ethernet can be slow to initialise and this check deals with those situations
 	loop_count_total=30
-	server_status="offline"
+	config_server_status="offline"
 	while (( loop_count_total > 0 )); do
             ping -c1 $config_ip >> transfer.log 2>&1
             if test ${PIPESTATUS[0]} -eq 0
             then
-                server_status="online"
-                printf "Server $config_ip online"
+                config_server_status="online"
+                printf "[`date`] Server $config_ip online\n"
                 break
             fi
-            printf "Waiting for ping response from sftp/ftp server, timeout in  $loop_count_total \r"
+            printf "[`date`] Waiting for ping response from sftp/ftp server, timeout in  $loop_count_total \r"
             ((loop_count_total--))
             sleep 1
         done
         if (( $loop_count_total == 0 ))
         then
-            printf "\nsftp/ftp ping timout\n"
+            printf "[`date`] \nsftp/ftp ping timout\n"
         fi
 
-	if [[ "$server_status" == "online" ]]
+	if [[ "$config_server_status" == "online" ]]
 	then
 		# ***** FTP TRANSFER *****
 		# If the protocol in shredos_config=".." is ftp then read the remote nwipe.conf and customers.csv files
@@ -394,6 +402,24 @@ then
 
 	done
 
+	# Has user specified shredos_autoreboot=enable on kernel command line?
+	# If yes, we need to makesure the --nowait option is applied as
+	# a command line option when we launch nwipe. However first
+	# we check the nwipe_options string to see if --nowait has already
+	# been applied. If no existing --nowait then we add it as a
+	# supplemental options.
+        autoreboot=$(kernel_cmdline_extractor shredos_autoreboot)
+	if [[ "$autoreboot" == "enable" ]]
+	then
+            case "$nwipe_options_string" in
+		*--nowait*)  ;;
+		*         ) launcher_options+="--nowait" ;;
+            esac
+        else
+            autoreboot=""
+        fi
+
+
 else
 	nwipe_options_flag=0	
 fi
@@ -407,9 +433,9 @@ while true
 do
 	if [ $nwipe_options_flag == 0 ]
 	then
-		/usr/bin/nwipe --logfile=$logfile $exclude_boot_disc_cmd
+		/usr/bin/nwipe --logfile=$logfile $launcher_options $exclude_boot_disc_cmd
 	else
-		/usr/bin/nwipe --logfile=$logfile $nwipe_options_string $exclude_boot_disc_cmd
+		/usr/bin/nwipe --logfile=$logfile $launcher_options $nwipe_options_string $exclude_boot_disc_cmd
 	fi
 
 	# ----
@@ -512,16 +538,16 @@ do
                 # Ping the ftp at 1 second intervals. Proceed as soon as a response is received
                 # If no response after 30 seconds proceed anyway and log a warning.
                 loop_count_total=30
-                server_status="offline"
+                output_server_status="offline"
                 while (( loop_count_total > 0 )); do
-                    ping -c1 $config_ip >> transfer.log 2>&1
+                    ping -c1 $output_ip >> transfer.log 2>&1
                     if test ${PIPESTATUS[0]} -eq 0
                     then
-                        server_status="online"
-                        printf "Server $config_ip online"
+                        output_server_status="online"
+                        printf "[`date`] Server $output_ip online\n"
                         break
                     fi
-                    printf "Waiting for ping response from sftp/ftp server, timeout in  $loop_count_total \r"
+                    printf "[`date`] Waiting for ping response from sftp/ftp server, timeout in  $loop_count_total \r"
                     ((loop_count_total--))
                     sleep 1
                     done
@@ -530,7 +556,7 @@ do
                     printf "\nsftp/ftp ping timout\n"
                 fi
 
-		if [[ "$server_status" == "online" ]]
+		if [[ "$output_server_status" == "online" ]]
 		then
 			# ***** FTP TRANSFER *****
 			#
@@ -547,6 +573,7 @@ do
 						mv $pdf exported/  2>&1 | tee -a transfer.log
 					else
 						printf "[`date`] Failed to send $pdf to ftp server $output_ip:$output_path\n" 2>&1 | tee -a transfer.log
+						transfer_status="FAIL"
 					fi
 				done
 
@@ -560,7 +587,8 @@ do
 						mv $log exported/  2>&1 | tee -a transfer.log
 					else
 						printf "[`date`] Failed to send $log to ftp server $output_ip:$output_path\n" 2>&1 | tee -a transfer.log
-					fi
+						transfer_status="FAIL"
+                                        fi
 				done
 			else
 				# ***** TFTP TRANSFER *****
@@ -570,34 +598,37 @@ do
 					# loop through all nwipe pdf files
 					for pdf in *.pdf
 					do
-						tftp $config_ip -v -m binary -c put $output_path/$pdf 2>&1 | tee -a transfer.log
-						tail -1 transfer.log | grep -i ERROR
+						tftp $output_ip -v -m binary -c put $output_path/$pdf 2>&1 | tee -a transfer.log
+						tail -1 transfer.log | grep -i "ERROR\|Transfer Timed out"
 						if test ${PIPESTATUS[1]} -ne 0
 						then
 							printf "[`date`] Sent $pdf to tftp server $output_ip:$output_path\n" 2>&1 | tee -a transfer.log
 							mv $pdf exported/  2>&1 | tee -a transfer.log
 						else
 							printf "[`date`] Failed to send $pdf to tftp server $output_ip:$output_path\n" 2>&1 | tee -a transfer.log
+							transfer_status="FAIL"
 						fi
 					done
 
 					#loop through all the logs
 					for log in nwipe_log*.txt
 					do
-						tftp $config_ip -v -m binary -c put $output_path/$log 2>&1 | tee -a transfer.log
-						tail -1 transfer.log | grep -i ERROR
+						tftp $output_ip -v -m binary -c put $output_path/$log 2>&1 | tee -a transfer.log
+						tail -1 transfer.log | grep -i "ERROR\|Transfer Timed out"
 						if test ${PIPESTATUS[1]} -ne 0
 						then
 							printf "[`date`] Sent $log to tftp server $output_ip:$output_path\n" 2>&1 | tee -a transfer.log
 							mv $log exported/  2>&1 | tee -a transfer.log
 						else
 							printf "[`date`] Failed to send $log to tftp server $output_ip:$output_path\n" 2>&1 | tee -a transfer.log
+							transfer_status="FAIL"
 						fi
 					done
 				fi
 			fi
 		else
 			printf "[`date`] Pinging $output_ip FAILED, Check RJ45 network connection\n" 2>&1 | tee -a transfer.log
+			transfer_status="FAIL"
 		fi
 	else
 		# if no shredos_output=".." on the kernel cmdline then assume we are booting from USB
@@ -612,7 +643,7 @@ do
 	fi
 
 	# If the config_ip was previously found on the kernel command line then
-	# write the config file and customers file, log files & pdfs to the tftp server.
+	# write the config file and customers file to the tftp server.
 	#
 	if [[ "$shredos_config_cmd_exists" == "yes" ]]
 	then
@@ -631,6 +662,7 @@ do
 				printf "[`date`] Sent nwipe.conf to ftp server $config_ip:$config_path\n" | tee -a transfer.log
 			else
 				printf "[`date`] Failed to send nwipe.conf to ftp server $config_ip:$config_path\n" | tee -a transfer.log
+				transfer_status="FAIL"
 			fi
 
 			lftp $output_debug -c "set xfer:clobber yes; open $config_ip; user $config_user $config_password; lcd /etc/nwipe; cd $config_path; put -e $customers_file; close" 2>&1 | tee -a transfer.log
@@ -639,6 +671,7 @@ do
 				printf "[`date`] Sent customers.csv to ftp server $config_ip:$config_path\n" 2>&1 | tee -a transfer.log
 			else
 				printf "[`date`] Failed to send customers.csv to ftp server $config_ip:$config_path\n" 2>&1 | tee -a transfer.log
+				transfer_status="FAIL"
 			fi
 
 			dmesg > dmesg.txt
@@ -648,6 +681,7 @@ do
 				printf "[`date`] Sent dmesg.txt to ftp server $config_ip:$config_path\n" 2>&1 | tee -a transfer.log
 			else
 				printf "[`date`] Failed to send dmesg.txt to ftp server $config_ip:$config_path\n" 2>&1 | tee -a transfer.log
+				transfer_status="FAIL"
 			fi
 		else
 			# ***** TFTP TRANSFER *****
@@ -655,31 +689,34 @@ do
 			if [[ "$config_protocol" == "tftp" ]]; then
 				printf "[`date`] TFTP protocol selected by the user\n" | tee -a transfer.log
 				tftp $config_ip -v -m binary -c put /etc/nwipe/$config_file $config_path/$config_file 2>&1 | tee -a transfer.log
-				tail -1 transfer.log | grep -i ERROR
+				tail -1 transfer.log | grep -i "ERROR\|Transfer Timed out"
 				if test ${PIPESTATUS[1]} -ne 0
 				then
 					printf "[`date`] Sent nwipe.conf to tftp server $config_ip:$config_path\n" | tee -a transfer.log
 				else
 					printf "[`date`] Failed to send nwipe.conf to tftp server $config_ip:$config_path\n" | tee -a transfer.log
+					transfer_status="FAIL"
 				fi
 
 				tftp $config_ip -v -m binary -c put /etc/nwipe/$customers_file $config_path/$customers_file 2>&1 | tee -a transfer.log
-				tail -1 transfer.log | grep -i ERROR
+				tail -1 transfer.log | grep -i "ERROR\|Transfer Timed out"
 				if test ${PIPESTATUS[1]} -ne 0
 				then
 					printf "[`date`] Sent customers.csv to tftp server $config_ip:$config_path\n" 2>&1 | tee -a transfer.log
 				else
 					printf "[`date`] Failed to send customers.csv to tftp server $config_ip:$config_path\n" 2>&1 | tee -a transfer.log
+					transfer_status="FAIL"
 				fi
 
 				dmesg > dmesg.txt
 				tftp $config_ip -v -m binary -c put $config_path/$dmesg_file 2>&1 | tee -a transfer.log
-				tail -1 transfer.log | grep -i ERROR
+				tail -1 transfer.log | grep -i "ERROR\|Transfer Timed out"
 				if [ ${PIPESTATUS[1]} -ne 0 ]
 				then
 					printf "[`date`] Sent dmesg.txt to tftp server $config_ip:$config_path\n" 2>&1 | tee -a transfer.log
 				else
 					printf "[`date`] Failed to send dmesg.txt to tftp server $config_ip:$config_path\n" 2>&1 | tee -a transfer.log
+					transfer_status="FAIL"
 				fi
 			fi
 		fi
@@ -688,22 +725,28 @@ do
 
 	# If the user has specified `shredos_autoreboot=enable` on the kernel command line
 	#
-	autoreboot=$(kernel_cmdline_extractor shredos_autoreboot)
-	if [ $? == 0 ]
+	if [ "$autoreboot" == "enable" ]
 	then
-		if [ "$autoreboot" == "enable" ]
-		then
-			shutdown -r now
-			# Waits while shutdown does it's stuff, without this sleep, the message above gets redisplayed.
-			sleep 10
-		fi
+                if  [[ "$transfer_status" == "SUCCESS" ]]
+                then
+                        shutdown -r now
+                        # Waits while shutdown does it's stuff, without this sleep, the message above gets redisplayed.
+                        sleep 30
+                else
+                        printf "[`date`] Although auto reboot requested, a transfer error occurred, waiting for user to review transfer.log\n" 2>&1 | tee -a transfer.log
+                fi
 	fi
 
 	# If the user specified --autopoweroff as a nwipe option then shutdown now
 	#
 	if [ $autopoweroff == 1 ]
 	then
-		init 0
+                if  [[ "$transfer_status" == "SUCCESS" ]]
+                then
+                        init 0
+                else
+                        printf "[`date`] Although auto power off requested, a transfer error occurred, so wait for user to review transfer.log\n" 2>&1 | tee -a transfer.log
+                fi
 	fi
 
 	exitloop="1"


### PR DESCRIPTION
Various fixes to do with tftp/ftp transfers.
Fixes #242 Pauses for upto 30 seconds before launching nwipe if ftp/tftp transfers are being used. This is because if the user specified shredos_config="..." on the kernel command line in order to retrieve the nwipe.conf and nwipe_customers.csv files from a local ftp/tftp server, the server needs to be online before nwipe is launched. On some systems/networks the ethernet hardware initialisation and then DHCP requests can be slower than nwipe launching hence why we now ping the server to makesure it's online before launching nwipe.

Lots of improvements to error detection and handling for tftp

Improvments to the "shredos_autoreboot=enable" option. When this option is placed on the kernel command line shredos will reboot upon completion of wipes. --nowait option is appled by the scipt to nwipe so nwipe doesn't wait for user interaction before exiting. If the shredos_config="..." or shredos_output="..." kernel command line options have been added by the user, autoreboot and also autoshutdown will wait after exiting nwipe if any ftp/tftp errors occurred so the user can review the transfer log and decide on a course of action if necessary.