### PR TITLE
Replaced the current nwipe.mk download option by a git submodule, poi..

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "external/nwipe"]
+	path = external/nwipe
+	url = https://github.com/martijnvanbrummelen/nwipe.git
+	branch = master

--- a/package/nwipe/nwipe.mk
+++ b/package/nwipe/nwipe.mk
@@ -4,15 +4,29 @@
 #
 ################################################################################
 
-NWIPE_VERSION = v0.37
-NWIPE_SITE = $(call github,martijnvanbrummelen,nwipe,$(NWIPE_VERSION))
+# Clones the nwipe master branch to external/nwipe auf der master branch
+NWIPE_VERSION = master
+NWIPE_SITE = NO_SITE
 NWIPE_DEPENDENCIES = ncurses parted dmidecode coreutils
 
+# The path for git init
+NWIPE_SUBMODULE_PATH = $(TOPDIR)/external/nwipe
+
 define NWIPE_INITSH
-	(cd $(@D) && cp ../../../package/nwipe/002-nwipe-banner-patch.sh $(@D) && ./002-nwipe-banner-patch.sh  && PATH="../../host/bin:${PATH}" ./autogen.sh);
+	(cd $(NWIPE_SUBMODULE_PATH) && cp ../../../package/nwipe/002-nwipe-banner-patch.sh $(NWIPE_SUBMODULE_PATH) && ./002-nwipe-banner-patch.sh && PATH="../../host/bin:${PATH}" ./autogen.sh);
 endef
 
 NWIPE_POST_PATCH_HOOKS += NWIPE_INITSH
 
+# Disables download procedure
+define DOWNLOAD_NWIPE
+	true
+endef
+
+# Copies the source out of the source path
+define NWIPE_EXTRACT_CMDS
+	rsync -a $(NWIPE_SUBMODULE_PATH)/ $(@D)/
+endef
 
 $(eval $(autotools-package))
+


### PR DESCRIPTION
…nting to master branch.

Ahoy.
I have used this approach to build my ShredOS release from the aes-ctr branch more easily.
The submodule always points to master, so it's easy exchangable, in my opinion more easy than have to download a release package etc.

