### PR TITLE
package/nwipe: switch from static tarball to Git commit (051e1aa)

### DIFF
--- a/package/nwipe/Config.in
+++ b/package/nwipe/Config.in
@@ -1,11 +1,50 @@
 config BR2_PACKAGE_NWIPE
-        bool "nwipe"
+	bool "nwipe"
 	select BR2_PACKAGE_NCURSES
 	select BR2_PACKAGE_PARTED
 	select BR2_PACKAGE_COREUTILS
 	select BR2_PACKAGE_DMIDECODE
 	select BR2_PACKAGE_LIBCONFIG
-        help
-          NWipe
+	help
+	  NWipe – secure disk wiping tool (fork of Darik's Boot and Nuke).
 
-comment "nwipe"
+if BR2_PACKAGE_NWIPE
+
+config BR2_PACKAGE_NWIPE_SITE
+	string "nwipe Git repository URL"
+	default "https://github.com/martijnvanbrummelen/nwipe.git"
+	help
+	  Git repository used to fetch the nwipe sources.
+	  This can be changed to point to a custom fork, e.g.:
+	    - https://github.com/youruser/nwipe.git
+	    - git@github.com:youruser/nwipe.git
+
+choice
+	prompt "nwipe version"
+	default BR2_PACKAGE_NWIPE_VERSION_STABLE
+	help
+	  Select which nwipe version (Git ref) should be built.
+
+config BR2_PACKAGE_NWIPE_VERSION_STABLE
+	bool "Stable tag (v0.39)"
+	help
+	  Use the previously hard-coded tag (v0.39) as a stable baseline.
+
+config BR2_PACKAGE_NWIPE_VERSION_GIT_REVISION
+	bool "Git revision"
+	help
+	  Use a user-specified Git revision (full commit SHA-1 or tag).
+
+endchoice
+
+config BR2_PACKAGE_NWIPE_GIT_REVISION
+	string "Git revision (full commit SHA-1 or tag)"
+	depends on BR2_PACKAGE_NWIPE_VERSION_GIT_REVISION
+	help
+	  When 'Git revision' is selected above, this string is passed as the
+	  Git ref to check out. Examples:
+	    - 051e1aa0c9572b26301a33d40689adb544927d11 (full commit SHA-1)
+	    - v0.39 (tag)
+
+endif
+

--- a/package/nwipe/nwipe.hash
+++ b/package/nwipe/nwipe.hash
@@ -1,1 +1,0 @@
-sha1    62adb09d04c8de18848efde4834115b7731a1c22  v0.39.tar.gz

--- a/package/nwipe/nwipe.mk
+++ b/package/nwipe/nwipe.mk
@@ -4,17 +4,37 @@
 #
 ################################################################################
 
-NWIPE_VERSION = 0.39
-NWIPE_SOURCE = v$(NWIPE_VERSION).tar.gz
-NWIPE_SITE = https://github.com/martijnvanbrummelen/nwipe/archive/refs/tags
+# Select the Git reference based on the Kconfig choice.
+ifeq ($(BR2_PACKAGE_NWIPE_VERSION_STABLE),y)
+NWIPE_VERSION = v0.39
+else ifeq ($(BR2_PACKAGE_NWIPE_VERSION_GIT_REVISION),y)
+NWIPE_VERSION = $(call qstrip,$(BR2_PACKAGE_NWIPE_GIT_REVISION))
+else
+# Fallback – should not happen because the choice enforces exactly one option
+NWIPE_VERSION = v0.39
+endif
 
-NWIPE_DEPENDENCIES = ncurses parted dmidecode coreutils
+# Default Git repository URL (never empty).
+NWIPE_SITE = https://github.com/martijnvanbrummelen/nwipe.git
+ifneq ($(call qstrip,$(BR2_PACKAGE_NWIPE_SITE)),)
+NWIPE_SITE = $(call qstrip,$(BR2_PACKAGE_NWIPE_SITE))
+endif
+
+NWIPE_SITE_METHOD = git
+
+NWIPE_DEPENDENCIES = ncurses parted dmidecode coreutils libconfig
 
 define NWIPE_INITSH
-    (cd $(@D) && cp ../../../package/nwipe/002-nwipe-banner-patch.sh $(@D) && ./002-nwipe-banner-patch.sh  && PATH="../../host/bin:${PATH}" ./autogen.sh);
+	(cd $(@D) && \
+		cp ../../../package/nwipe/002-nwipe-banner-patch.sh . && \
+		./002-nwipe-banner-patch.sh && \
+		PATH="../../host/bin:${PATH}" ./autogen.sh)
 endef
 
-#NWIPE_POST_PATCH_HOOKS += NWIPE_INITSH
+# Pre-configure hook, as a post-patch hook would not get triggered on a package
+# reconfigure, and possibly also taint the sources directory with the generated
+# autogen files (which should not be there).
 NWIPE_PRE_CONFIGURE_HOOKS += NWIPE_INITSH
 
 $(eval $(autotools-package))
+


### PR DESCRIPTION
This commit updates the nwipe package to build from a specific Git commit instead of using the previously referenced tarball release. The changes include:

- Setting NWIPE_SITE to the GitHub repository and NWIPE_SITE_METHOD to git.
- Specifying the commit hash (051e1aa) in NWIPE_VERSION.
- Removing or emptying the nwipe.hash file, as we no longer verify a tarball and instead rely on the Git checkout.

This approach allows ShredOS/Buildroot to clone the nwipe repository at commit 051e1aa, apply the banner patch, and build the nwipe binary directly from Git.

You can specify the desired commit in the nwipe.mk file.