### PR TITLE
Dynamically calculate vfat size based on bzImage size plus 20MB

### DIFF
--- a/board/shredos/genimage_i586.cfg
+++ b/board/shredos/genimage_i586.cfg
@@ -12,7 +12,7 @@ image boot.vfat {
                 file autorun.inf            { image = 'autorun.inf' }
         }
 
-        size = 380000000
+size = 74137344
 }
 
 image shredos.img {

--- a/configs/shredos_i686_lite_defconfig
+++ b/configs/shredos_i686_lite_defconfig
@@ -6,6 +6,7 @@ BR2_TARGET_GENERIC_HOSTNAME="shredos"
 BR2_TARGET_GENERIC_ISSUE="Welcome to ShredOS https://github.com/PartialVolume/shredos.i686"
 BR2_INIT_SYSV=y
 BR2_ROOTFS_MERGED_USR=y
+BR2_SYSTEM_BIN_SH_BASH=y
 BR2_SYSTEM_DEFAULT_PATH="/bin:/sbin:/usr/bin:/usr/sbin"
 # BR2_ENABLE_LOCALE_PURGE is not set
 BR2_ROOTFS_OVERLAY="board/shredos/fsoverlay"


### PR DESCRIPTION
Modified make_img_file.sh so that the vfat partition size is dynamically calculated based on the bzImage size plus an arbitary 20MB added to accommodate the extra files including PDF reports and logs.