### PR TITLE
Added i386 legacy boot

### DIFF
--- a/configs/shredos_iso_extra_defconfig
+++ b/configs/shredos_iso_extra_defconfig
@@ -179,7 +179,10 @@ BR2_TARGET_ROOTFS_ISO9660_HYBRID=y
 BR2_TARGET_ROOTFS_ISO9660_HYBRID_APPEND_PARTITION="extra.vfat"
 # BR2_TARGET_ROOTFS_TAR is not set
 BR2_TARGET_GRUB2=y
+BR2_TARGET_GRUB2_I386_PC=y
 BR2_TARGET_GRUB2_X86_64_EFI=y
+BR2_TARGET_GRUB2_BUILTIN_MODULES_PC="boot linux ext2 fat squash4 part_msdos part_gpt normal progress biosdisk video video_fb all_video video_cirrus video_bochs net tftp gzio test eval read true gfxterm gfxterm_menu gfxmenu gfxterm_background png usb usb_keyboard search configfile iso9660"
+BR2_TARGET_GRUB2_BUILTIN_CONFIG_PC="board/shredos/embed/grub.cfg"
 BR2_TARGET_GRUB2_BUILTIN_MODULES_EFI="boot linux ext2 fat squash4 part_msdos part_gpt normal progress efi_gop efi_uga video video_fb all_video video_cirrus video_bochs net efinet tftp gzio test eval read true gfxterm gfxterm_menu gfxmenu gfxterm_background png usb usb_keyboard search configfile iso9660"
 BR2_TARGET_GRUB2_BUILTIN_CONFIG_EFI="board/shredos/embed/grub.cfg"
 BR2_TARGET_GRUB2_INSTALL_TOOLS=y


### PR DESCRIPTION
Added i386 legacy boot required to boot one of my systems, EFI USB & CD and legacy USB & CD tested. All booting with shredos_iso_extra_defconfig. Confirmed ShredOS mounts the 50MB extra partition on the USB and uses for configs, logs and PDFs.