### PR TITLE
Increased the grub and isolinux boot menu delay from 5 to 15 seconds

### DIFF
--- a/board/shredos/grub.cfg
+++ b/board/shredos/grub.cfg
@@ -1,5 +1,5 @@
 set default="0"
-set timeout="5"
+set timeout="15"
 
 menuentry "ShredOS" {
     linux /boot/bzImage console=tty3 loglevel=3

--- a/board/shredos/iso/grub.cfg
+++ b/board/shredos/iso/grub.cfg
@@ -1,5 +1,5 @@
 set default="0"
-set timeout="5"
+set timeout="15"
 
 menuentry "ShredOS" {
     linux __KERNEL_PATH__ console=tty3 loglevel=3

--- a/board/shredos/iso/isolinux.cfg
+++ b/board/shredos/iso/isolinux.cfg
@@ -1,6 +1,6 @@
 default menu.c32
 prompt 0
-timeout 50
+timeout 150
 
 menu title ShredOS
 


### PR DESCRIPTION
Increased the grub and isolinux boot menu delay from 5 to 15 seconds due to the boot menus now having an increased number of entries for the user to look at. Specifically the additional memtest entries.