### PR TITLE
Fix: Always use a newly timestamped log file on nwipe restart.

### DIFF
--- a/board/shredos/fsoverlay/usr/bin/nwipe_launcher
+++ b/board/shredos/fsoverlay/usr/bin/nwipe_launcher
@@ -363,7 +363,6 @@ nwipe_options_string=""
 lftp_command_line=""
 http_post_url=""
 autopoweroff=0
-logfile="nwipe_log_$(date +%Y%m%d-%H%M%S).txt"
 
 # read the kernel command line for the loadkeys label for setting the correct keyboard layout
 #
@@ -482,6 +481,7 @@ do
 	pre_wipe_options=""
 	post_wipe_url=""
 	post_wipe_options=""
+	logfile="nwipe_log_$(date +%Y%m%d-%H%M%S).txt"
 
 	pre_wipe_string=$(kernel_cmdline_extractor shredos_pre_wipe)
 	if [ $? == 0 ]


### PR DESCRIPTION
On an nwipe restart (as opposed to a reboot), the same nwipe_log file name was used therefore overwriting the previous nwipe_log file. This fix corrects that bug so that on a nwipe restart a fresh correctly timestamped nwipe_log filename is generated.

This problem was referenced in a issue or discussion but I can't find it so am unable to close that particular issue. If anybody remembers where this was originally referenced please let me know so it can be closed. Thanks.