### PR TITLE
Add NWIPE_VERSION to build environment

### DIFF
--- a/package/nwipe/nwipe.mk
+++ b/package/nwipe/nwipe.mk
@@ -9,6 +9,7 @@ NWIPE_VERSION = $(call qstrip,$(BR2_PACKAGE_NWIPE_GIT_REVISION))
 NWIPE_DEPENDENCIES = ncurses parted dmidecode coreutils libconfig libnvme
 NWIPE_CONF_OPTS = --with-libnvme
 NWIPE_SITE_METHOD = git
+NWIPE_MAKE_ENV = NWIPE_GIT_HASH=$(NWIPE_VERSION)
 
 ifneq ($(call qstrip,$(BR2_PACKAGE_NWIPE_SITE)),)
 NWIPE_SITE = $(call qstrip,$(BR2_PACKAGE_NWIPE_SITE))

--- a/package/nwipe/nwipe.mk
+++ b/package/nwipe/nwipe.mk
@@ -9,7 +9,7 @@ NWIPE_VERSION = $(call qstrip,$(BR2_PACKAGE_NWIPE_GIT_REVISION))
 NWIPE_DEPENDENCIES = ncurses parted dmidecode coreutils libconfig libnvme
 NWIPE_CONF_OPTS = --with-libnvme
 NWIPE_SITE_METHOD = git
-NWIPE_MAKE_ENV = NWIPE_GIT_HASH=$(NWIPE_VERSION)
+NWIPE_MAKE_ENV = NWIPE_GIT_HASH="$(NWIPE_VERSION)"
 
 ifneq ($(call qstrip,$(BR2_PACKAGE_NWIPE_SITE)),)
 NWIPE_SITE = $(call qstrip,$(BR2_PACKAGE_NWIPE_SITE))


### PR DESCRIPTION
This adds the Nwipe version to the build environment, so Nwipe can pick it up for its log output later.

<img width="697" height="152" alt="image" src="https://github.com/user-attachments/assets/07adaba4-af79-4897-8b9d-92e283e7e3f0" />